### PR TITLE
fix: crash on inputs containing runs of 4 spaces

### DIFF
--- a/sembr/processors/base.py
+++ b/sembr/processors/base.py
@@ -24,7 +24,7 @@ class BaseProcessor(ABC):
         self.spaces = spaces
         self.replace_tokens = self._get_replace_tokens()
         self.reverse_replace_tokens = {
-            v: k for k, v in self.replace_tokens.items() if k != "\t"
+            v: k for k, v in self.replace_tokens.items()
         }
 
     @abstractmethod

--- a/sembr/processors/latex.py
+++ b/sembr/processors/latex.py
@@ -22,7 +22,6 @@ class LaTeXProcessor(BaseProcessor):
             Dictionary mapping original tokens to replacement tokens
         """
         return {
-            "\t": " " * self.spaces,
             "\\%": "[percent]",
             "\n": "[newline]",
         }

--- a/sembr/processors/markdown.py
+++ b/sembr/processors/markdown.py
@@ -34,7 +34,6 @@ class MarkdownProcessor(BaseProcessor):
 
     def _get_replace_tokens(self) -> Dict[str, str]:
         return {
-            "\t": " " * self.spaces,
             "\n": "[newline]",
         }
 
@@ -128,6 +127,7 @@ class MarkdownProcessor(BaseProcessor):
 
     def parse_text(self, text: str, split: bool = True) -> List[Dict[str, Any]]:
         """Parse text to find inline content regions."""
+        text = text.replace("\t", " " * self.spaces)
         self._original_text = text
         text_regions = self._identify_content_regions(text)
         # Process each text region

--- a/sembr/processors/plaintext.py
+++ b/sembr/processors/plaintext.py
@@ -22,7 +22,6 @@ class PlainTextProcessor(BaseProcessor):
             Dictionary mapping original tokens to replacement tokens
         """
         return {
-            '\t': ' ' * self.spaces,
             '\n': '[newline]',
         }
 


### PR DESCRIPTION
fixes: #7 

The processors register their replace_tokens values with the tokenizer via tokenizer.add_tokens(). The 4-space string used for the "\t" -> spaces substitution seems like it has no row in the sembr2023 model's embedding matrix. This means any input with four or more consecutive spaces therefore produces an out-of-range token ID and crashes with:

    IndexError: index out of range in self

Reproducer:

    printf 'hello    world' | uvx sembr

The fix in this PR is to not register the 4-space string with the tokenizer. Since its registration was a result of being a value in replace_tokens, I removed it from the dict and handle the tab-to-spaces substitution separately:

- MarkdownProcessor, LaTeXProcessor, PlainTextProcessor: drop the `"\t": " " * self.spaces` entry from _get_replace_tokens.
- MarkdownProcessor.parse_text: add an explicit text.replace("\t", " " * self.spaces). The other two processors already did this substitution.
- BaseProcessor: drop the now-dead "if k != '\t'" filter from reverse_replace_tokens.