### PR TITLE
fix: include internal parts of sembr in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ Homepage = "https://github.com/admk/sembr"
 Issues = "https://github.com/admk/sembr/issues"
 
 [tool.setuptools.packages.find]
-include = ["sembr"]
+include = ["sembr", "sembr.*"]
 exclude = ["data*", "tests*"]
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
I ran into an error when trying to use uvx to run my fix from the GitHub repo.

You can reproduce it with this:

```text
printf 'hello' | uvx --from "git+ssh://git@github.com/admk/sembr@main" sembr
```

This PR fixes the issue by adding "sembr.*" to the includes.